### PR TITLE
Add required headers to plugin

### DIFF
--- a/src/bbpress.php
+++ b/src/bbpress.php
@@ -21,7 +21,7 @@
  * Text Domain: bbpress
  * Domain Path: /languages/
  * License:     GPLv2 or later (license.txt)
- * Requires WP: 5.3
+ * Requires at least: 5.3
  * Requires PHP: 5.6.20
  */
 

--- a/src/bbpress.php
+++ b/src/bbpress.php
@@ -21,6 +21,8 @@
  * Text Domain: bbpress
  * Domain Path: /languages/
  * License:     GPLv2 or later (license.txt)
+ * Requires at least: 5.3
+ * Requires PHP: 5.6.20
  */
 
 // Exit if accessed directly

--- a/src/bbpress.php
+++ b/src/bbpress.php
@@ -21,7 +21,7 @@
  * Text Domain: bbpress
  * Domain Path: /languages/
  * License:     GPLv2 or later (license.txt)
- * Requires at least: 5.3
+ * Requires WP: 5.3
  * Requires PHP: 5.6.20
  */
 


### PR DESCRIPTION
WordPress core supports these headers now, so a core project, we should add these headers.