### PR TITLE
Add support for block themes

### DIFF
--- a/src/includes/core/theme-compat.php
+++ b/src/includes/core/theme-compat.php
@@ -846,6 +846,14 @@ function bbp_template_include_theme_compat( $template = '' ) {
 		$template = bbp_get_theme_compat_templates();
 	}
 
+	/*
+	* If the current theme is a WordPress Block Theme, bbPress needs to use
+	* the WordPress template canvas to retrieve the correct content.
+	*/
+	if ( current_theme_supports( 'block-templates' ) ) {
+		$template = ABSPATH . WPINC . '/template-canvas.php';
+	}
+
 	// Filter & return
 	return apply_filters( 'bbp_template_include_theme_compat', $template );
 }

--- a/src/includes/core/theme-compat.php
+++ b/src/includes/core/theme-compat.php
@@ -846,10 +846,10 @@ function bbp_template_include_theme_compat( $template = '' ) {
 		$template = bbp_get_theme_compat_templates();
 	}
 
-	/*
-	* If the current theme is a WordPress Block Theme, bbPress needs to use
-	* the WordPress template canvas to retrieve the correct content.
-	*/
+	/**
+	 * If the current theme is a WordPress Block Theme, bbPress needs to use
+	 * the WordPress template canvas to retrieve the correct content.
+	 */
 	if ( current_theme_supports( 'block-templates' ) ) {
 		$template = ABSPATH . WPINC . '/template-canvas.php';
 	}


### PR DESCRIPTION
This PR tries out adding support for block themes.

It checks if the current theme supports `block-templates`, and if so, uses the `template-canvas.php` as the main template.

This solution is based on [this comment](https://bbpress.trac.wordpress.org/ticket/3487#comment:1).

To test, try enabling bbPress with the Twenty Twenty-Two or Twenty Twenty-Three themes. Without this PR, the forum pages will not render. With this PR, they should render correctly.

Trac ticket: https://bbpress.trac.wordpress.org/ticket/3487