### PR TITLE
Enabled editing with Gutenberg editor

### DIFF
--- a/src/bbpress.php
+++ b/src/bbpress.php
@@ -526,6 +526,7 @@ final class bbPress {
 				'query_var'           => true,
 				'menu_icon'           => '',
 				'source'              => 'bbpress',
+				'show_in_rest'        => true,
 			) )
 		);
 
@@ -552,6 +553,7 @@ final class bbPress {
 				'query_var'           => true,
 				'menu_icon'           => '',
 				'source'              => 'bbpress',
+				'show_in_rest'        => true,
 			) )
 		);
 
@@ -578,6 +580,7 @@ final class bbPress {
 				'query_var'           => true,
 				'menu_icon'           => '',
 				'source'              => 'bbpress',
+				'show_in_rest'        => true,
 			) )
 		);
 	}


### PR DESCRIPTION
Showing bbPress post types in REST API, to enable editing experience with Gutenberg editor.

Track link:
https://bbpress.trac.wordpress.org/ticket/3525
