### PR TITLE
Replace deprecated utf8_encode()

### DIFF
--- a/src/includes/replies/template.php
+++ b/src/includes/replies/template.php
@@ -1100,7 +1100,7 @@ function bbp_reply_author_display_name( $reply_id = 0 ) {
 
 		// Encode possible UTF8 display names
 		if ( seems_utf8( $author_name ) === false ) {
-			$author_name = utf8_encode( $author_name );
+			$author_name = mb_convert_encoding( $author_name, 'UTF-8', mb_list_encodings() );
 		}
 
 		// Filter & return

--- a/src/includes/topics/template.php
+++ b/src/includes/topics/template.php
@@ -1333,7 +1333,7 @@ function bbp_topic_author_display_name( $topic_id = 0 ) {
 
 		// Encode possible UTF8 display names
 		if ( seems_utf8( $author_name ) === false ) {
-			$author_name = utf8_encode( $author_name );
+			$author_name = mb_convert_encoding( $author_name, 'UTF-8', mb_list_encodings() );
 		}
 
 		// Filter & return


### PR DESCRIPTION
utf8_encode will be removed with PHP 9 and is deprecated in PHP 8.2.

Replacing it with mb_convert_encoding(), doing a reasonable guess of the character encoding.