### PR TITLE
Fix issue what causes WP_List_Table to throw a critical error

### DIFF
--- a/src/includes/topics/template.php
+++ b/src/includes/topics/template.php
@@ -2067,7 +2067,7 @@ function bbp_topic_reply_count( $topic_id = 0, $integer = false ) {
 			? 'bbp_get_topic_reply_count_int'
 			: 'bbp_get_topic_reply_count';
 
-		return apply_filters( $filter, $replies, $topic_id );
+		return (int) apply_filters( $filter, $replies, $topic_id );
 	}
 
 /**
@@ -2129,7 +2129,7 @@ function bbp_topic_reply_count_hidden( $topic_id = 0, $integer = false ) {
 			? 'bbp_get_topic_reply_count_hidden_int'
 			: 'bbp_get_topic_reply_count_hidden';
 
-		return apply_filters( $filter, $replies, $topic_id );
+		return (int) apply_filters( $filter, $replies, $topic_id );
 	}
 
 /**


### PR DESCRIPTION
# Problem

If users change the `bbp_get_topic_reply_count` so that a non-integer value is returned, it causes a critical error that makes the editor inaccessable.

# Solution

Type cast the return value to integer to ensure we do not allow such errors to occur