### PR TITLE
bbp_sanitize_search_request() - Support nested arrays correctly.

### DIFF
--- a/src/includes/search/functions.php
+++ b/src/includes/search/functions.php
@@ -126,6 +126,7 @@ function bbp_sanitize_search_request( $query_arg = 's' ) {
 
 	// Maybe implode if an array
 	if ( is_array( $terms ) ) {
+		$terms = array_filter( $terms, 'is_scalar' );
 		$terms = implode( ' ', $terms );
 	}
 


### PR DESCRIPTION
A request such as `?ts[]=term` passes through this function, but `?ts[][]=term` causes a PHP Warning: `Array to string conversion`.

As it attempts to run:
`implode($separator = ' ', $array = [ 0 => [0 => 'term']])`