### PR TITLE
Fix: Cast post__not_in to array in forum visibility query

### DIFF
--- a/src/includes/forums/functions.php
+++ b/src/includes/forums/functions.php
@@ -2329,7 +2329,7 @@ function bbp_pre_get_posts_normalize_forum_visibility( $posts_query = null ) {
 		if ( ! empty( $forum_ids ) ) {
 
 			// Get any existing not-in queries
-			$not_in = $posts_query->get( 'post__not_in', array() );
+			$not_in = (array) $posts_query->get( 'post__not_in', array() );
 
 			// Add our not-in to existing
 			$not_in = array_unique( array_merge( $not_in, $forum_ids ) );


### PR DESCRIPTION
Ensures  is always an array before array_merge to prevent fatal error

Issue: https://bbpress.trac.wordpress.org/ticket/3636