### PR TITLE
Fix: Use revision meta author in topic/reply revision logs

### DIFF
--- a/src/includes/replies/template.php
+++ b/src/includes/replies/template.php
@@ -757,7 +757,13 @@ function bbp_reply_revision_log( $reply_id = 0 ) {
 				$reason    = $revision_log[ $revision->ID ]['reason'];
 			}
 
-			$author = bbp_get_author_link( array( 'size' => 14, 'link_text' => bbp_get_reply_author_display_name( $revision->ID ), 'post_id' => $revision->ID ) );
+			// Get author display name directly from author ID
+			$author_name = get_the_author_meta( 'display_name', $author_id );
+			if ( empty( $author_name ) ) {
+				$author_name = get_the_author_meta( 'user_login', $author_id );
+			}
+			
+			$author = bbp_get_author_link( array( 'size' => 14, 'link_text' => $author_name, 'post_id' => $author_id ) );
 			$since  = bbp_get_time_since( bbp_convert_date( $revision->post_modified ) );
 
 			$r .= "\t" . '<li id="bbp-reply-revision-log-' . esc_attr( $reply_id ) . '-item-' . esc_attr( $revision->ID ) . '" class="bbp-reply-revision-log-item">' . "\n";

--- a/src/includes/topics/template.php
+++ b/src/includes/topics/template.php
@@ -924,7 +924,13 @@ function bbp_topic_revision_log( $topic_id = 0 ) {
 				$reason    = $revision_log[ $revision->ID ]['reason'];
 			}
 
-			$author = bbp_get_author_link( array( 'size' => 14, 'link_text' => bbp_get_topic_author_display_name( $revision->ID ), 'post_id' => $revision->ID ) );
+			// Get author display name directly from author ID
+			$author_name = get_the_author_meta( 'display_name', $author_id );
+			if ( empty( $author_name ) ) {
+				$author_name = get_the_author_meta( 'user_login', $author_id );
+			}
+			
+			$author = bbp_get_author_link( array( 'size' => 14, 'link_text' => $author_name, 'post_id' => $author_id ) );
 			$since  = bbp_get_time_since( bbp_convert_date( $revision->post_modified ) );
 
 			$retval .= "\t" . '<li id="bbp-topic-revision-log-' . esc_attr( $topic_id ) . '-item-' . esc_attr( $revision->ID ) . '" class="bbp-topic-revision-log-item">' . "\n";


### PR DESCRIPTION
### Summary

This PR fixes an issue where `bbp_get_reply_revision_log()` and `bbp_get_topic_revision_log()` would always display the original revision author, even if a different author was set in the revision log meta.

### Details

- The functions now check for an `author` value in the revision log meta for each revision.
- If present, the log displays the name and link for the meta author; otherwise, it falls back to the original revision's `post_author`.
- This allows filters (such as on `bbp_get_reply_raw_revision_log`) to override the displayed author for moderation or other purposes.

### References

- bbPress Trac [#3579](https://bbpress.trac.wordpress.org/ticket/3579)