### PR TITLE
Fix: Use page title for archive pages when WP page exists at same path

### DIFF
--- a/src/includes/core/theme-compat.php
+++ b/src/includes/core/theme-compat.php
@@ -647,7 +647,7 @@ function bbp_template_include_theme_compat( $template = '' ) {
 		// Reset post
 		bbp_theme_compat_reset_post( array(
 			'ID'             => ! empty( $page->ID ) ? $page->ID : 0,
-			'post_title'     => bbp_get_topic_archive_title(),
+			'post_title'     => $new_title,
 			'post_author'    => 0,
 			'post_date'      => bbp_get_empty_datetime(),
 			'post_content'   => $new_content,

--- a/src/templates/default/extras/archive-forum.php
+++ b/src/templates/default/extras/archive-forum.php
@@ -14,7 +14,7 @@ get_header(); ?>
 	<?php do_action( 'bbp_template_notices' ); ?>
 
 	<div id="forum-front" class="bbp-forum-front">
-		<h1 class="entry-title"><?php bbp_forum_archive_title(); ?></h1>
+		<h1 class="entry-title"><?php the_title(); ?></h1>
 		<div class="entry-content">
 
 			<?php bbp_get_template_part( 'content', 'archive-forum' ); ?>

--- a/src/templates/default/extras/archive-topic.php
+++ b/src/templates/default/extras/archive-topic.php
@@ -14,7 +14,7 @@ get_header(); ?>
 	<?php do_action( 'bbp_template_notices' ); ?>
 
 	<div id="topic-front" class="bbp-topics-front">
-		<h1 class="entry-title"><?php bbp_topic_archive_title(); ?></h1>
+		<h1 class="entry-title"><?php the_title(); ?></h1>
 		<div class="entry-content">
 
 			<?php bbp_get_template_part( 'content', 'archive-topic' ); ?>


### PR DESCRIPTION
### Summary

Fixes archive page titles to use WordPress page titles when a page exists at the same path, instead of always showing bbPress archive titles.

### Changes

- **Theme compatibility**: Fixed topic archive to use `$new_title` instead of always calling `bbp_get_topic_archive_title()`
- **Archive templates**: Changed from `bbp_forum_archive_title()`/`bbp_topic_archive_title()` to `the_title()` to respect theme compatibility layer

bbPress Trac  [#3604](https://bbpress.trac.wordpress.org/ticket/3604)
