### PR TITLE
Fix: Allow 'Spam' action on trashed replies in admin links

### DIFF
--- a/src/includes/replies/template.php
+++ b/src/includes/replies/template.php
@@ -1798,14 +1798,9 @@ function bbp_reply_admin_links( $args = array() ) {
 
 		// See if links need to be unset
 		$reply_status = bbp_get_reply_status( $r['id'] );
-		if ( in_array( $reply_status, array( bbp_get_spam_status_id(), bbp_get_trash_status_id(), bbp_get_pending_status_id() ), true ) ) {
-
-			// Spam link shouldn't be visible on trashed topics
-			if ( bbp_get_trash_status_id() === $reply_status ) {
-				unset( $r['links']['spam'] );
-
+		if ( in_array( $reply_status, array( bbp_get_spam_status_id(), bbp_get_pending_status_id() ), true ) ) {
 			// Trash link shouldn't be visible on spam topics
-			} elseif ( bbp_get_spam_status_id() === $reply_status ) {
+			if ( bbp_get_spam_status_id() === $reply_status ) {
 				unset( $r['links']['trash'] );
 			}
 		}


### PR DESCRIPTION
### Summary

Allows moderators to mark trashed replies as spam from the front end by making the "Spam" action available on trashed replies. Previously, the "Spam" link was hidden for trashed replies, requiring them to be restored before marking as spam.

**Changes:**

- Removes the logic that hid the "Spam" link for trashed replies in `bbp_get_reply_admin_links()`
- The "Trash" link remains hidden for spam replies as before

bbPress Trac  [#3411](https://bbpress.trac.wordpress.org/ticket/3411)