### PR TITLE
Docs: Fix missing inline documentation tags and formatting.

### DIFF
--- a/src/bbpress.php
+++ b/src/bbpress.php
@@ -96,9 +96,9 @@ final class bbPress {
 	/**
 	 * Main bbPress Instance
 	 *
-	 * bbPress is fun
-	 * Please load it only one time
-	 * For this, we thank you
+	 * bbPress is fun.
+	 * Please load it only one time.
+	 * For this, we thank you.
 	 *
 	 * Insures that only one instance of bbPress exists in memory at any one
 	 * time. Also prevents needing to define globals all over the place.
@@ -107,7 +107,7 @@ final class bbPress {
 	 *
 	 * @staticvar object $instance
 	 * @see bbpress()
-	 * @return bbPress The one true bbPress
+	 * @return bbPress The one true bbPress.
 	 */
 	public static function instance() {
 

--- a/src/includes/admin/classes/class-bbp-admin.php
+++ b/src/includes/admin/classes/class-bbp-admin.php
@@ -23,91 +23,91 @@ class BBP_Admin {
 	/** Directory *************************************************************/
 
 	/**
-	 * @var string Path to the bbPress admin directory
+	 * @var string Path to the bbPress admin directory.
 	 */
 	public $admin_dir = '';
 
 	/** URLs ******************************************************************/
 
 	/**
-	 * @var string URL to the bbPress admin directory
+	 * @var string URL to the bbPress admin directory.
 	 */
 	public $admin_url = '';
 
 	/**
-	 * @var string URL to the bbPress images directory
+	 * @var string URL to the bbPress images directory.
 	 */
 	public $images_url = '';
 
 	/**
-	 * @var string URL to the bbPress admin styles directory
+	 * @var string URL to the bbPress admin styles directory.
 	 */
 	public $styles_url = '';
 
 	/**
-	 * @var string URL to the bbPress admin css directory
+	 * @var string URL to the bbPress admin css directory.
 	 */
 	public $css_url = '';
 
 	/**
-	 * @var string URL to the bbPress admin js directory
+	 * @var string URL to the bbPress admin js directory.
 	 */
 	public $js_url = '';
 
 	/** Capability ************************************************************/
 
 	/**
-	 * @var bool Minimum capability to access Tools and Settings
+	 * @var bool Minimum capability to access Tools and Settings.
 	 */
 	public $minimum_capability = 'keep_gate';
 
 	/** Separator *************************************************************/
 
 	/**
-	 * @var bool Whether or not to add an extra top level menu separator
+	 * @var bool Whether or not to add an extra top level menu separator.
 	 */
 	public $show_separator = false;
 
 	/** Tools *****************************************************************/
 
 	/**
-	 * @var array Array of available repair tools
+	 * @var array Array of available repair tools.
 	 */
 	public $tools = array();
 
 	/** Notices ***************************************************************/
 
 	/**
-	 * @var array Array of notices to output to the current user
+	 * @var array Array of notices to output to the current user.
 	 */
 	public $notices = array();
 
 	/** Components ************************************************************/
 
 	/**
-	 * @var BBP_Forums_Admin Forums admin
+	 * @var BBP_Forums_Admin Forums admin.
 	 */
 	public $forums = null;
 
 	/**
-	 * @var BBP_Topics_Admin Topics admin
+	 * @var BBP_Topics_Admin Topics admin.
 	 */
 	public $topics = null;
 
 	/**
-	 * @var BBP_Replies_Admin Replies admin
+	 * @var BBP_Replies_Admin Replies admin.
 	 */
 	public $replies = null;
 
 	/**
-	 * @var BBP_Converter Converter admin
+	 * @var BBP_Converter Converter admin.
 	 */
 	public $converter = null;
 
 	/** Functions *************************************************************/
 
 	/**
-	 * The main bbPress admin loader
+	 * The main bbPress admin loader.
 	 *
 	 * @since 2.0.0 bbPress (r2515)
 	 */
@@ -118,7 +118,7 @@ class BBP_Admin {
 	}
 
 	/**
-	 * Admin globals
+	 * Admin globals.
 	 *
 	 * @since 2.0.0 bbPress (r2646)
 	 *
@@ -139,7 +139,7 @@ class BBP_Admin {
 	}
 
 	/**
-	 * Include required files
+	 * Include required files.
 	 *
 	 * @since 2.0.0 bbPress (r2646)
 	 *
@@ -167,7 +167,7 @@ class BBP_Admin {
 	}
 
 	/**
-	 * Setup the admin hooks, actions and filters
+	 * Setup the admin hooks, actions and filters.
 	 *
 	 * @since 2.0.0 bbPress (r2646)
 	 *
@@ -306,7 +306,7 @@ class BBP_Admin {
 	}
 
 	/**
-	 * Output all admin area notices
+	 * Output all admin area notices.
 	 *
 	 * @since 2.6.0 bbPress (r6771)
 	 */
@@ -334,11 +334,11 @@ class BBP_Admin {
 	 *
 	 * @since 2.6.0 bbPress (r6771)
 	 *
-	 * @param string|WP_Error $message        A message to be displayed or {@link WP_Error}
-	 * @param string          $class          Optional. A class to be added to the message div
-	 * @param bool            $is_dismissible Optional. True to dismiss, false to persist
+	 * @param string|WP_Error $message        A message to be displayed or {@link WP_Error}.
+	 * @param string          $class          Optional. A class to be added to the message div.
+	 * @param bool            $is_dismissible Optional. True to dismiss, false to persist.
 	 *
-	 * @return void
+	 * @return bool|void False on failure, void otherwise.
 	 */
 	public function add_notice( $message, $class = false, $is_dismissible = true ) {
 
@@ -396,11 +396,11 @@ class BBP_Admin {
 	}
 
 	/**
-	 * Escape message string output
+	 * Escape message string output.
 	 *
 	 * @since 2.6.0 bbPress (r6775)
 	 *
-	 * @param string $message
+	 * @param string $message The message.
 	 *
 	 * @return string
 	 */
@@ -448,7 +448,7 @@ class BBP_Admin {
 	}
 
 	/**
-	 * Add the admin menus
+	 * Add the admin menus.
 	 *
 	 * @since 2.0.0 bbPress (r2646)
 	 */

--- a/src/includes/forums/functions.php
+++ b/src/includes/forums/functions.php
@@ -18,8 +18,10 @@ defined( 'ABSPATH' ) || exit;
  *
  * @since 2.0.0 bbPress (r3349)
  *
- * @param array $forum_data Forum post data
- * @param array $forum_meta Forum meta data
+ * @param array $forum_data Forum post data.
+ * @param array $forum_meta Forum meta data.
+ *
+ * @return int|false Forum ID on success, false on failure.
  */
 function bbp_insert_forum( $forum_data = array(), $forum_meta = array() ) {
 
@@ -110,9 +112,9 @@ function bbp_insert_forum( $forum_data = array(), $forum_meta = array() ) {
 /** Post Form Handlers ********************************************************/
 
 /**
- * Handles the front end forum submission
+ * Handles the front end forum submission.
  *
- * @param string $action The requested action to compare this function to
+ * @param string $action The requested action to compare this function to.
  */
 function bbp_new_forum_handler( $action = '' ) {
 
@@ -364,9 +366,9 @@ function bbp_new_forum_handler( $action = '' ) {
 }
 
 /**
- * Handles the front end edit forum submission
+ * Handles the front end edit forum submission.
  *
- * @param string $action The requested action to compare this function to
+ * @param string $action The requested action to compare this function to.
  */
 function bbp_edit_forum_handler( $action = '' ) {
 
@@ -1131,7 +1133,6 @@ function bbp_bump_forum_topic_count( $forum_id = 0, $difference = 1, $update_anc
  * @since 2.6.0 bbPress (r6036)
  *
  * @param int $forum_id The forum id.
- * @return void
  */
 function bbp_increase_forum_topic_count( $forum_id = 0 ) {
 
@@ -1163,7 +1164,6 @@ function bbp_increase_forum_topic_count( $forum_id = 0 ) {
  *
  * @param int $forum_id The forum id.
  *
- * @return void
  */
 function bbp_decrease_forum_topic_count( $forum_id = 0 ) {
 
@@ -1254,7 +1254,6 @@ function bbp_bump_forum_topic_count_hidden( $forum_id = 0, $difference = 1, $upd
  *
  * @param int $forum_id The forum id.
  *
- * @return void
  */
 function bbp_increase_forum_topic_count_hidden( $forum_id = 0 ) {
 
@@ -1286,7 +1285,6 @@ function bbp_increase_forum_topic_count_hidden( $forum_id = 0 ) {
  *
  * @param int $forum_id The forum id.
  *
- * @return void
  */
 function bbp_decrease_forum_topic_count_hidden( $forum_id = 0 ) {
 
@@ -1436,7 +1434,6 @@ function bbp_bump_forum_reply_count_hidden( $forum_id = 0, $difference = 1, $upd
  *
  * @param int $forum_id The forum id.
  *
- * @return void
  */
 function bbp_increase_forum_reply_count( $forum_id = 0 ) {
 
@@ -1468,7 +1465,6 @@ function bbp_increase_forum_reply_count( $forum_id = 0 ) {
  *
  * @param int $forum_id The forum id.
  *
- * @return void
  */
 function bbp_decrease_forum_reply_count( $forum_id = 0 ) {
 
@@ -1500,7 +1496,6 @@ function bbp_decrease_forum_reply_count( $forum_id = 0 ) {
  *
  * @param int $forum_id The forum id.
  *
- * @return void
  */
 function bbp_increase_forum_reply_count_hidden( $forum_id = 0 ) {
 
@@ -1532,7 +1527,6 @@ function bbp_increase_forum_reply_count_hidden( $forum_id = 0 ) {
  *
  * @param int $forum_id The forum id.
  *
- * @return void
  */
 function bbp_decrease_forum_reply_count_hidden( $forum_id = 0 ) {
 
@@ -1564,7 +1558,6 @@ function bbp_decrease_forum_reply_count_hidden( $forum_id = 0 ) {
  *
  * @param int $topic_id The topic id.
  *
- * @return void
  */
 function bbp_approved_unapproved_topic_update_forum_reply_count( $topic_id = 0 ) {
 

--- a/src/includes/replies/functions.php
+++ b/src/includes/replies/functions.php
@@ -18,8 +18,10 @@ defined( 'ABSPATH' ) || exit;
  *
  * @since 2.0.0 bbPress (r3349)
  *
- * @param array $reply_data Forum post data
- * @param array $reply_meta Forum meta data
+ * @param array $reply_data Forum post data.
+ * @param array $reply_meta Forum meta data.
+ *
+ * @return int|false Reply ID on success, false on failure.
  */
 function bbp_insert_reply( $reply_data = array(), $reply_meta = array() ) {
 
@@ -94,8 +96,6 @@ function bbp_insert_reply( $reply_data = array(), $reply_meta = array() ) {
  * @param int $reply_id The reply id.
  * @param int $topic_id The topic id.
  * @param int $forum_id The forum id.
- *
- * @return void
  */
 function bbp_insert_reply_update_counts( $reply_id = 0, $topic_id = 0, $forum_id = 0 ) {
 
@@ -114,13 +114,13 @@ function bbp_insert_reply_update_counts( $reply_id = 0, $topic_id = 0, $forum_id
 /** Post Form Handlers ********************************************************/
 
 /**
- * Handles the front end reply submission
+ * Handles the front end reply submission.
  *
  * @since 2.0.0 bbPress (r2574)
  *
  * @param string $action The requested action to compare this function to
  *                    id, anonymous data, reply author, edit (false), and
- *                    the reply to id
+ *                    the reply to id.
  */
 function bbp_new_reply_handler( $action = '' ) {
 

--- a/src/includes/topics/functions.php
+++ b/src/includes/topics/functions.php
@@ -18,8 +18,10 @@ defined( 'ABSPATH' ) || exit;
  *
  * @since 2.0.0 bbPress (r3349)
  *
- * @param array $topic_data Forum post data
- * @param array $topic_meta Forum meta data
+ * @param array $topic_data Forum post data.
+ * @param array $topic_meta Forum meta data.
+ *
+ * @return int|false Topic ID on success, false on failure.
  */
 function bbp_insert_topic( $topic_data = array(), $topic_meta = array() ) {
 
@@ -89,9 +91,9 @@ function bbp_insert_topic( $topic_data = array(), $topic_meta = array() ) {
 /** Post Form Handlers ********************************************************/
 
 /**
- * Handles the front end topic submission
+ * Handles the front end topic submission.
  *
- * @param string $action The requested action to compare this function to
+ * @param string $action The requested action to compare this function to.
  */
 function bbp_new_topic_handler( $action = '' ) {
 
@@ -421,9 +423,9 @@ function bbp_new_topic_handler( $action = '' ) {
 }
 
 /**
- * Handles the front end edit topic submission
+ * Handles the front end edit topic submission.
  *
- * @param string $action The requested action to compare this function to
+ * @param string $action The requested action to compare this function to.
  */
 function bbp_edit_topic_handler( $action = '' ) {
 
@@ -2364,8 +2366,6 @@ function bbp_bump_topic_reply_count( $topic_id = 0, $difference = 1 ) {
  * @since 2.6.0 bbPress (r6036)
  *
  * @param int $topic_id The topic id.
- *
- * @return void
  */
 function bbp_increase_topic_reply_count( $topic_id = 0 ) {
 
@@ -2396,8 +2396,6 @@ function bbp_increase_topic_reply_count( $topic_id = 0 ) {
  * @since 2.6.0 bbPress (r6036)
  *
  * @param int $topic_id The topic id.
- *
- * @return void
  */
 function bbp_decrease_topic_reply_count( $topic_id = 0 ) {
 
@@ -2457,8 +2455,6 @@ function bbp_bump_topic_reply_count_hidden( $topic_id = 0, $difference = 1 ) {
  * @since 2.6.0 bbPress (r6036)
  *
  * @param int $topic_id The topic id.
- *
- * @return void
  */
 function bbp_increase_topic_reply_count_hidden( $topic_id = 0 ) {
 
@@ -2489,8 +2485,6 @@ function bbp_increase_topic_reply_count_hidden( $topic_id = 0 ) {
  * @since 2.6.0 bbPress (r6036)
  *
  * @param int $topic_id The topic id.
- *
- * @return void
  */
 function bbp_decrease_topic_reply_count_hidden( $topic_id = 0 ) {
 
@@ -2522,8 +2516,6 @@ function bbp_decrease_topic_reply_count_hidden( $topic_id = 0 ) {
  *
  * @param int $topic_id The topic id.
  * @param int $forum_id The forum id.
- *
- * @return void
  */
 function bbp_insert_topic_update_counts( $topic_id = 0, $forum_id = 0 ) {
 

--- a/src/includes/users/signups.php
+++ b/src/includes/users/signups.php
@@ -14,7 +14,7 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Output the forum-role field when adding a new user
+ * Output the forum-role field when adding a new user.
  *
  * @since 2.6.0 bbPress (r6674)
  */
@@ -60,11 +60,11 @@ function bbp_add_user_form_role_field() {
 }
 
 /**
- * Maybe add forum role to signup meta array
+ * Maybe add forum role to signup meta array.
  *
  * @since 2.6.0 bbPress (r6674)
  *
- * @param array $meta
+ * @param array $meta The signup meta.
  *
  * @return array
  */
@@ -96,7 +96,7 @@ function bbp_user_add_role_to_signup_meta( $meta = array() ) {
 }
 
 /**
- * Add forum meta data when inviting a user to a site
+ * Add forum meta data when inviting a user to a site.
  *
  * @since 2.6.0 bbPress (r6674)
  *
@@ -140,11 +140,11 @@ function bbp_user_add_role_on_invite( $user_id = '', $role = '', $newuser_key = 
 }
 
 /**
- * Single-site handler for adding a new user
+ * Single-site handler for adding a new user.
  *
  * @since 2.6.0 bbPress (r6674)
  *
- * @param int $user_id
+* @param int $user_id The user ID.
  *
  * @return void
  */
@@ -168,13 +168,13 @@ function bbp_user_add_role_on_register( $user_id = '' ) {
 }
 
 /**
- * Multi-site handler for adding a new user
+ * Multi-site handler for adding a new user.
  *
  * @since 2.6.0 bbPress (r6674)
  *
- * @param int    $user_id  User ID
- * @param string $password User password
- * @param array  $meta     Array of metadata
+ * @param int    $user_id  User ID.
+ * @param string $password User password.
+ * @param array  $meta     Array of metadata.
  *
  * @return void
  */
@@ -209,9 +209,9 @@ function bbp_user_add_role_on_activate( $user_id = 0, $password = '', $meta = ar
  *
  * @since 2.6.5
  *
- * @param string $to_validate A role ID to validate
+ * @param string $to_validate A role ID to validate.
  *
- * @return string A valid role ID, or empty string on error
+ * @return string A valid role ID, or empty string on error.
  */
 function bbp_validate_signup_role( $to_validate = '' ) {
 
@@ -238,13 +238,13 @@ function bbp_validate_signup_role( $to_validate = '' ) {
 }
 
 /**
- * Validate the Forum role during the registration process
+ * Validate the Forum role during the registration process.
  *
  * @since 2.6.5
  *
- * @param string $to_validate A role ID to validate
+ * @param string $to_validate A role ID to validate.
  *
- * @return string A valid role ID, or empty string on error
+ * @return string A valid role ID, or empty string on error.
  */
 function bbp_validate_registration_role( $to_validate = '' ) {
 
@@ -265,7 +265,7 @@ function bbp_validate_registration_role( $to_validate = '' ) {
 }
 
 /**
- * Validate the Forum role during multisite activation
+ * Validate the Forum role during multisite activation.
  *
  * This function exists simply for parity with registrations, and to maintain an
  * intentional layer of abstraction from the more generic function it uses.
@@ -275,9 +275,9 @@ function bbp_validate_registration_role( $to_validate = '' ) {
  *
  * @since 2.6.5
  *
- * @param string $to_validate A role ID to validate
+ * @param string $to_validate A role ID to validate.
  *
- * @return string A valid role ID, or empty string on error
+ * @return string A valid role ID, or empty string on error.
  */
 function bbp_validate_activation_role( $to_validate = '' ) {
 


### PR DESCRIPTION
This PR improves the inline documentation coverage and formatting across several core files to align with WordPress PHP Documentation Standards.
## Changes
- Added missing `@return` tags.
- Fixed missing full stops (periods) in function summaries and descriptions.
- Populated missing `@param` descriptions.
## Files Modified
- `src/includes/admin/classes/class-bbp-admin.php`
- `src/includes/forums/functions.php`
- `src/includes/replies/functions.php`
- `src/includes/topics/functions.php`
- `src/includes/users/signups.php`

See [#3659](https://bbpress.trac.wordpress.org/ticket/3659)