### PR TITLE
Docs: Fix @since tag for bbp_get_redirect_to()

### DIFF
--- a/src/includes/common/functions.php
+++ b/src/includes/common/functions.php
@@ -42,7 +42,7 @@ function bbp_get_post_types( $args = array() ) {
 /**
  * Return the unescaped redirect_to request value
  *
- * @bbPress (r4655)
+ * @since bbPress (r4655)
  *
  * @return string The URL to redirect to, if set
  */


### PR DESCRIPTION
Fixes an incorrect docblock tag by replacing a non-standard bbPress tag with a proper since tag.

No functional changes.
