### PR TITLE
Docs: improve PHPDoc return annotations

### DIFF
--- a/src/includes/admin/tools.php
+++ b/src/includes/admin/tools.php
@@ -58,7 +58,7 @@ function bbp_admin_tools_box() {
  * @since 2.6.0 bbPress (r5885)
  *
  * @param array $args
- * @return
+ * @return void
  */
 function bbp_register_repair_tool( $args = array() ) {
 

--- a/src/includes/extend/buddypress/functions.php
+++ b/src/includes/extend/buddypress/functions.php
@@ -317,7 +317,7 @@ function bbp_maybe_delete_group_forum_root( $forum_id = 0 ) {
  *
  * @since 2.6.0 bbPress (r6479)
  *
- * @return
+ * @return void
  */
 function bbp_maybe_create_group_forum_root() {
 


### PR DESCRIPTION
Adds missing `@return void` annotations to two docblocks.

No functional changes.
