### PR TITLE
Added Missing Global Documentation in some files

### DIFF
--- a/src/bbpress.php
+++ b/src/bbpress.php
@@ -623,6 +623,8 @@ final class bbPress {
 	 * replies can be viewed from within the theme.
 	 *
 	 * @since 2.0.0 bbPress (r2727)
+	 * 
+	 * @global WP_Post_Status[] $wp_post_statuses
 	 */
 	public static function register_post_statuses() {
 

--- a/src/includes/admin/common.php
+++ b/src/includes/admin/common.php
@@ -16,6 +16,8 @@ defined( 'ABSPATH' ) || exit;
  * Add a separator to the WordPress admin menus.
  *
  * @since 2.0.0 bbPress (r2957)
+ *
+ * @global menu $menu
  */
 function bbp_admin_separator() {
 

--- a/src/includes/core/cache.php
+++ b/src/includes/core/cache.php
@@ -85,6 +85,8 @@ class BBP_Skip_Children {
 	 *
 	 * @since 2.1.0 bbPress (r4011)
 	 *
+	 * @global bool $_wp_suspend_cache_invalidation
+	 *
 	 * @param int $post_id The post ID of the cache being invalidated.
 	 */
 	public function skip_related_posts( $post_id = 0 ) {


### PR DESCRIPTION
Added Missing Global Documentation in below files

1. src/bbpress.php
2. src/includes/admin/common.php
3. src/includes/core/cache.php

Trac Ticket: [#3663](https://bbpress.trac.wordpress.org/ticket/3663)