### PR TITLE
Replies: avoid bool-increment deprecation in bbp_get_reply_position_raw()

### DIFF
--- a/src/includes/replies/functions.php
+++ b/src/includes/replies/functions.php
@@ -2471,8 +2471,13 @@ function bbp_get_reply_position_raw( $reply_id = 0, $topic_id = 0 ) {
 				$topic_replies  = array_reverse( $topic_replies );
 				$reply_position = array_search( $reply_id, $topic_replies, true );
 
-				// Bump the position to compensate for the lead topic post
-				++$reply_position;
+				// Bump the position to compensate for the lead topic post,
+				// or reset to 0 if the reply was not found in the children list.
+				if ( false !== $reply_position ) {
+					++$reply_position;
+				} else {
+					$reply_position = 0;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Fixes the PHP 8.3+ `Increment on type bool has no effect` warning emitted from `bbp_get_reply_position_raw()`:

```
PHP Warning:  Increment on type bool has no effect, this will change in
the next major version of PHP in
.../bbpress/includes/replies/functions.php on line 2475
```

## Root cause

`array_search()` returns `false` when the reply isn't in the children list returned by `bbp_get_all_child_ids()`. That list is built by a SQL query that excludes `draft` and `future` statuses (`src/includes/common/functions.php`), and is also subject to the `bbp_get_all_child_ids` filter. So `false` is returned in several realistic scenarios:

- The reply has `post_status` of `draft` or `future`.
- The reply's `post_parent` doesn't match the `$topic_id` passed in (callers pass a stale `$topic_id`, or the reply was moved).
- A plugin filters the reply out via the `bbp_get_all_child_ids` filter (moderation plugins hiding pending replies, etc.).
- Object-cache staleness for the `bbpress_posts` cache group.
- `$reply_id` resolves to `0` or to a reply outside this topic.

In all of those, `++$reply_position` then operates on `false`, which is a deprecated no-op in PHP 8.3+ and a fatal in PHP 9. The function subsequently returns `(int) false === 0` — silently claiming the reply is in lead-post position. The deprecation is exposing a latent silent-wrong-answer bug.

## Fix

Guard the increment behind a `false !== $reply_position` check, and explicitly reset to `0` in the not-found case. This preserves the current return-0 behaviour for any downstream consumer while removing the deprecation.

## Related

- Trac ticket: https://bbpress.trac.wordpress.org/ticket/3671

## Test environment

PHP 8.4.21, bbPress 2.7.0-alpha-2 / current trunk.