### PR TITLE
Extend - Akismet: store time() in history events instead of microtime() float

### DIFF
--- a/src/includes/extend/akismet.php
+++ b/src/includes/extend/akismet.php
@@ -728,13 +728,9 @@ class BBP_Akismet {
 			$user = $current_user->user_login;
 		}
 
-		// This used to be akismet_microtime() but it was removed in 3.0
-		$mtime        = explode( ' ', microtime() );
-		$message_time = $mtime[1] + $mtime[0];
-
 		// Setup the event to be saved
 		$event = array(
-			'time'    => $message_time,
+			'time'    => time(),
 			'message' => $message,
 			'event'   => $event,
 			'user'    => $user,
@@ -995,8 +991,8 @@ class BBP_Akismet {
 
 							<tr>
 								<td style="color: #999; text-align: right; white-space: nowrap;">
-									<span title="<?php echo esc_attr( gmdate( 'D d M Y @ h:i:m a', $row['time'] ) . ' GMT' ); ?>">
-										<?php bbp_time_since( $row['time'], false, true ); ?>
+									<span title="<?php echo esc_attr( gmdate( 'D d M Y @ h:i:m a', (int) $row['time'] ) . ' GMT' ); ?>">
+										<?php bbp_time_since( (int) $row['time'], false, true ); ?>
 									</span>
 								</td>
 								<td style="padding-left: 5px;">


### PR DESCRIPTION
Fixes the PHP 8.1+ `Implicit conversion from float to int loses precision` deprecation emitted every time the Akismet history metabox renders for a topic or reply:

```
PHP Deprecated:  Implicit conversion from float 1779210785.780218 to int
loses precision in .../bbpress/includes/extend/akismet.php on line 994
```

## Root cause

`BBP_Akismet::update_post_history()` stores a fractional `microtime()` float in each `_bbp_akismet_history` event:

```php
// This used to be akismet_microtime() but it was removed in 3.0
$mtime        = explode( ' ', microtime() );
$message_time = $mtime[1] + $mtime[0];

$event = array(
    'time' => $message_time,   // float, e.g. 1779210785.780218
    ...
);
```

The two readers — `gmdate()` and `bbp_time_since()` — both expect `int` and operate on whole seconds, so the sub-second precision is recorded, persisted to post meta forever, then thrown away on every read. PHP 8.1+ deprecates the implicit lossy float-to-int conversion at the read site.

The inlined `explode(' ', microtime())` + add pattern is a relic from the pre-PHP-5.0 string-form of `microtime()` (the inline comment says "This used to be `akismet_microtime()` but it was removed in 3.0"). It was inlined into bbPress verbatim when Akismet 3.0 dropped the helper, but the rationale for sub-second precision didn't carry over to bbPress.

## Fix

Two changes that need to ship together:

1. **Write site** — store `time()` (int) so new history rows don't have unused sub-second precision.
2. **Read sites** — cast `(int)` on the two consumers (`gmdate()` and `bbp_time_since()`), so the deprecation also goes away for the millions of legacy float rows already in `_bbp_akismet_history` post meta.

Read-site-only would still create new float rows; write-site-only would still warn forever on existing data.

## Related

- Trac ticket: https://bbpress.trac.wordpress.org/ticket/3672

## Test environment

PHP 8.4.21, bbPress 2.7.0-alpha-2 / current trunk.